### PR TITLE
refactor: 다이어리 dto-to-record

### DIFF
--- a/backend/src/main/java/org/example/povi/domain/diary/entry/dto/request/DiaryCreateReq.java
+++ b/backend/src/main/java/org/example/povi/domain/diary/entry/dto/request/DiaryCreateReq.java
@@ -3,36 +3,24 @@ package org.example.povi.domain.diary.entry.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.example.povi.domain.diary.type.MoodEmoji;
 import org.example.povi.domain.diary.type.Visibility;
 
 import java.util.List;
 
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class DiaryCreateReq {
 
-    @NotNull
-    private Long userId;
-
-    @NotBlank
-    @Size(min = 2, max = 50)
-    private String title;
-
-    @NotBlank
-    @Size(min = 10, max = 3000)
-    private String content;
-
-    @NotNull
-    private MoodEmoji moodEmoji;
-
-    private Visibility visibility;
-
-    @Size(max = 3)
-    private List<String> imageUrls;
-}
+public record DiaryCreateReq(
+        @NotNull
+        Long userId,
+        @NotBlank @Size(min = 2, max = 50)
+        String title,
+        @NotBlank @Size(min = 10, max = 3000)
+        String content,
+        @NotNull
+        MoodEmoji moodEmoji,
+        @NotNull
+        Visibility visibility,
+        @Size(max = 3)
+        List<String> imageUrls
+) {}

--- a/backend/src/main/java/org/example/povi/domain/diary/entry/dto/request/DiaryUpdateReq.java
+++ b/backend/src/main/java/org/example/povi/domain/diary/entry/dto/request/DiaryUpdateReq.java
@@ -1,28 +1,22 @@
 package org.example.povi.domain.diary.entry.dto.request;
 
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.example.povi.domain.diary.type.MoodEmoji;
 import org.example.povi.domain.diary.type.Visibility;
 
 import java.util.List;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class DiaryUpdateReq {
 
-    @Size(min = 2, max = 50)
-    private String title;
+public record DiaryUpdateReq(
+        @Size(min = 2, max = 50)
+        String title,
 
-    @Size(min = 10, max = 3000)
-    private String content;
+        @Size(min = 10, max = 3000)
+        String content,
 
-    private MoodEmoji moodEmoji;
-    private Visibility visibility;
+        MoodEmoji moodEmoji,
+        Visibility visibility,
 
-    @Size(max = 3)
-    private List<String> imageUrls;
-}
+        @Size(max = 3)
+        List<String> imageUrls
+) {}

--- a/backend/src/main/java/org/example/povi/domain/diary/entry/dto/response/DiaryCreateRes.java
+++ b/backend/src/main/java/org/example/povi/domain/diary/entry/dto/response/DiaryCreateRes.java
@@ -1,7 +1,5 @@
 package org.example.povi.domain.diary.entry.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
 import org.example.povi.domain.diary.entry.entity.DiaryEntry;
 import org.example.povi.domain.diary.entry.entity.DiaryImage;
 import org.example.povi.domain.diary.type.MoodEmoji;
@@ -10,28 +8,26 @@ import org.example.povi.domain.diary.type.Visibility;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Builder
-public class DiaryCreateRes {
-    private final Long diaryId;
-    private final String title;
-    private final String content;
-    private final MoodEmoji moodEmoji;
-    private final Visibility visibility;
-    private final List<String> imageUrls;
-    private final LocalDateTime createdAt;
-
+public record DiaryCreateRes(
+        Long diaryId,
+        String title,
+        String content,
+        MoodEmoji moodEmoji,
+        Visibility visibility,
+        List<String> imageUrls,
+        LocalDateTime createdAt
+) {
     public static DiaryCreateRes from(DiaryEntry diaryEntry) {
-        return DiaryCreateRes.builder()
-                .diaryId(diaryEntry.getId())
-                .title(diaryEntry.getTitle())
-                .content(diaryEntry.getContent())
-                .moodEmoji(diaryEntry.getMoodEmoji())
-                .visibility(diaryEntry.getVisibility())
-                .imageUrls(diaryEntry.getImages().stream()
+        return new DiaryCreateRes(
+                diaryEntry.getId(),
+                diaryEntry.getTitle(),
+                diaryEntry.getContent(),
+                diaryEntry.getMoodEmoji(),
+                diaryEntry.getVisibility(),
+                diaryEntry.getImages().stream()
                         .map(DiaryImage::getImageUrl)
-                        .toList())
-                .createdAt(diaryEntry.getCreatedAt())
-                .build();
+                        .toList(),
+                diaryEntry.getCreatedAt()
+        );
     }
 }

--- a/backend/src/main/java/org/example/povi/domain/diary/entry/dto/response/DiaryUpdateRes.java
+++ b/backend/src/main/java/org/example/povi/domain/diary/entry/dto/response/DiaryUpdateRes.java
@@ -1,7 +1,5 @@
 package org.example.povi.domain.diary.entry.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
 import org.example.povi.domain.diary.entry.entity.DiaryEntry;
 import org.example.povi.domain.diary.entry.entity.DiaryImage;
 import org.example.povi.domain.diary.type.MoodEmoji;
@@ -10,31 +8,29 @@ import org.example.povi.domain.diary.type.Visibility;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Getter
-@Builder
-public class DiaryUpdateRes {
-    private final Long diaryId;
-    private final String title;
-    private final String content;
-    private final MoodEmoji moodEmoji;
-    private final Visibility visibility;
-    private final List<String> imageUrls;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
-
+public record DiaryUpdateRes(
+        Long diaryId,
+        String title,
+        String content,
+        MoodEmoji moodEmoji,
+        Visibility visibility,
+        List<String> imageUrls,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
     public static DiaryUpdateRes from(DiaryEntry diaryEntry) {
-        return DiaryUpdateRes.builder()
-                .diaryId(diaryEntry.getId())
-                .title(diaryEntry.getTitle())
-                .content(diaryEntry.getContent())
-                .moodEmoji(diaryEntry.getMoodEmoji())
-                .visibility(diaryEntry.getVisibility())
-                .imageUrls(diaryEntry.getImages().stream()
+        return new DiaryUpdateRes(
+                diaryEntry.getId(),
+                diaryEntry.getTitle(),
+                diaryEntry.getContent(),
+                diaryEntry.getMoodEmoji(),
+                diaryEntry.getVisibility(),
+                diaryEntry.getImages().stream()
                         .map(DiaryImage::getImageUrl)
-                        .toList())
-                .createdAt(diaryEntry.getCreatedAt())
-                .updatedAt(diaryEntry.getUpdatedAt())
-                .build();
+                        .toList(),
+                diaryEntry.getCreatedAt(),
+                diaryEntry.getUpdatedAt()
+        );
     }
 }
 

--- a/backend/src/main/java/org/example/povi/domain/diary/entry/service/DiaryService.java
+++ b/backend/src/main/java/org/example/povi/domain/diary/entry/service/DiaryService.java
@@ -33,22 +33,22 @@ public class DiaryService {
 
     @Transactional
     public DiaryCreateRes create(DiaryCreateReq req) {
-        User user = userRepository.findById(req.getUserId())
+        User user = userRepository.findById(req.userId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 
-        String title   = normalizeRequired(req.getTitle(), TITLE_MIN, TITLE_MAX, "제목");
-        String content = normalizeRequired(req.getContent(), CONTENT_MIN, CONTENT_MAX, "내용");
+        String title = normalizeRequired(req.title(), TITLE_MIN, TITLE_MAX, "제목");
+        String content = normalizeRequired(req.content(), CONTENT_MIN, CONTENT_MAX, "내용");
 
         DiaryEntry diaryEntry = DiaryEntry.builder()
                 .user(user)
                 .title(title)
                 .content(content)
-                .moodEmoji(req.getMoodEmoji())
-                .visibility(req.getVisibility())
+                .moodEmoji(req.moodEmoji())
+                .visibility(req.visibility())
                 .build();
 
         // 이미지(생성)
-        List<String> urls = normalizeImagesForCreate(req.getImageUrls());
+        List<String> urls = normalizeImagesForCreate(req.imageUrls());
         if (urls != null) {
             urls.forEach(u -> diaryEntry.addImage(new DiaryImage(diaryEntry, u)));
         }
@@ -65,22 +65,22 @@ public class DiaryService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Diary not found"));
 
         // 제목
-        if (req.getTitle() != null) {
-            String title = normalizeRequired(req.getTitle(), TITLE_MIN, TITLE_MAX, "제목");
+        if (req.title() != null) {
+            String title = normalizeRequired(req.title(), TITLE_MIN, TITLE_MAX, "제목");
             diaryEntry.renameTo(title);
         }
         // 내용
-        if (req.getContent() != null) {
-            String content = normalizeRequired(req.getContent(), CONTENT_MIN, CONTENT_MAX, "내용");
+        if (req.content() != null) {
+            String content = normalizeRequired(req.content(), CONTENT_MIN, CONTENT_MAX, "내용");
             diaryEntry.rewriteContent(content);
         }
         // 이모지/공개범위
-        if (req.getMoodEmoji() != null) diaryEntry.changeMood(req.getMoodEmoji());
-        if (req.getVisibility() != null) diaryEntry.changeVisibility(req.getVisibility());
+        if (req.moodEmoji() != null) diaryEntry.changeMood(req.moodEmoji());
+        if (req.visibility() != null) diaryEntry.changeVisibility(req.visibility());
 
         // 이미지: null=미변경 / []=모두삭제 / 값있음=전체교체
-        if (req.getImageUrls() != null) {
-            List<String> normalized = normalizeImagesForPatch(req.getImageUrls());
+        if (req.imageUrls() != null) {
+            List<String> normalized = normalizeImagesForPatch(req.imageUrls());
             diaryEntry.replaceImages(normalized);
         }
 


### PR DESCRIPTION
## 📌 과제 설명
- 다이어리 기능에서 DTO 클래스를 -> record 타입으로 리팩토링 했습니다.

## 👩‍💻 요구 사항과 구현 내용
- DTO 클래스 → record 타입으로 변환
- DiaryCreateReq, DiaryUpdateReq, DiaryCreateRes, DiaryUpdateRes
- Lombok 어노테이션 제거 (@Getter, @Builder, @NoArgsConstructor 등)
- Bean Validation 어노테이션(@NotNull, @Size, @NotBlank) 유지
- 서비스/컨트롤러 로직 변경 없음 (record 구조 대응만)

## ✅ 피드백 반영사항  
## ✅ PR 포인트 & 궁금한 점 